### PR TITLE
fixing url size

### DIFF
--- a/app/common/components/forms/fields.factory.js
+++ b/app/common/components/forms/fields.factory.js
@@ -27,6 +27,12 @@ function fieldsFactory ($translate, Notification, $q) {
    * @type {number}
    */
   const STR_XSM_SIZE = 16
+  /**
+   * @alias module:fields.URL_SIZE
+   * The less size for one url is for internet explorer with 2048 characters
+   * @type {number}
+   */
+  const URL_SIZE = 2048
 
   /**
    * Generates formly fields.

--- a/app/common/components/forms/resource.fields.factory.js
+++ b/app/common/components/forms/resource.fields.factory.js
@@ -258,7 +258,7 @@ function resourceFields (fields, resources, enums) {
     constructor (model, ...fields) {
       const def = {namespace: 'r.tradedocument'}
       super(model,
-        new f.String('url', _.defaults({maxLength: fields.STR_BIG_SIZE}, def)),
+        new f.String('url', _.defaults({maxLength: fields.URL_SIZE}, def)),
         new f.String('documentId', _.defaults({maxLength: fields.STR_BIG_SIZE}, def)),
         new f.String('description', _.defaults({maxLength: fields.STR_BIG_SIZE}, def)),
         new f.Datepicker('date', def),


### PR DESCRIPTION
fixing the limit to 64 characters and allow now 2028. Internet Explorer is the browser with less characters allow and this limit is 2048 characters